### PR TITLE
Upgrade minder-action to v0.1.0, use built-in GitHub Actions token

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This action [installs the Minder CLI](https://mindersec.github.io/getting_starte
 Before using this action, you will need to grant the GitHub Action role permission to manage your Minder project.  You can use the `project role grant` sub-command to grant permissions on the server, for example:
 
 ```bash
-minder project role grant --grpc-host api.custcodian.dev \
+minder project role grant \
   --project 00000000-0000-0000-0000-000000000000 \
   --sub githubactions/repo:myorg/myrepo:ref:refs/heads/main \
   --role admin
@@ -51,7 +51,7 @@ jobs:
         # the action will install the minder CLI and add it to the PATH, but
         # will not apply any configuration, so you can (for example) generate
         # configuration and apply it in a later step.
-        directory: .github/minderconfig
+        directory: .github/minder
 ```
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   release:
     description: 'The Minder client release to download and use. Defaults to a specific version for each release of the action.'
     required: false
-    default: 'v0.0.88'
+    default: 'v0.1.0'
 runs:
   using: composite
   steps:
@@ -34,20 +34,6 @@ runs:
       uses: mindersec/minder-client-installer@v1.0.0
       with:
         release: ${{ inputs.release }}
-    # TODO: rather than setting $MINDER_TOKEN, build this into the minder CLI
-    # ACTIONS_ID_TOKEN_REQUEST_URL is set by GitHub Actions when the id-token
-    # permission is available.
-    - name: Fetch ID token
-      shell: bash
-      run: |
-        set -x -e
-          echo $GITHUB_TOKEN
-          URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=minder"
-          curl -o .action-token -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" $URL
-          # Mask the token as a secret, so it won't be printed to the logs
-          echo "::add-mask::$(jq -r .value <.action-token)"
-          echo "MINDER_AUTH_TOKEN=$(jq -r .value <.action-token)" >> "$GITHUB_ENV"
-          rm .action-token
     - name: Apply Minder ruletypes
       if: (inputs.project != '' && inputs.directory != '')
       shell: bash


### PR DESCRIPTION
The Minder v0.1.0 client has been published for a few weeks and seems to be stable, but we never got around to upgrading these instructions.

